### PR TITLE
Add Spring Boot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# resume
+# Resume Spring Boot Application
+
+This project is a simple Spring Boot application configured with Spring Web and Thymeleaf. It was generated without network access and includes minimal setup files for Gradle or Maven.
+
+## Running the application
+
+```
+# Using Gradle
+./gradlew bootRun
+
+# Or if Maven is available
+mvn spring-boot:run
+```
+
+The main class is `com.example.resume.ResumeApplication`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>resume</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>resume</name>
+  <description>Demo Spring Boot Resume Application</description>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'resume'

--- a/src/main/java/com/example/resume/HomeController.java
+++ b/src/main/java/com/example/resume/HomeController.java
@@ -1,0 +1,15 @@
+package com.example.resume;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String home(Model model) {
+        model.addAttribute("message", "Welcome to the Resume Application");
+        return "index";
+    }
+}

--- a/src/main/java/com/example/resume/ResumeApplication.java
+++ b/src/main/java/com/example/resume/ResumeApplication.java
@@ -1,0 +1,12 @@
+package com.example.resume;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ResumeApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ResumeApplication.class, args);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=8080

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Resume App</title>
+</head>
+<body>
+<h1 th:text="${message}">Message</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize Spring Boot project using Gradle or Maven
- create simple controller and template
- add README with run instructions

## Testing
- `gradle --no-daemon build` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7ffdb288322ab8464e85875d87b