### PR TITLE
Add basic resume controller and templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>resume</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>resume</name>
+    <description>Simple resume generator</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/example/resume/ResumeApplication.java
+++ b/src/main/java/com/example/resume/ResumeApplication.java
@@ -1,0 +1,12 @@
+package com.example.resume;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ResumeApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ResumeApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/resume/controller/ResumeController.java
+++ b/src/main/java/com/example/resume/controller/ResumeController.java
@@ -1,0 +1,64 @@
+package com.example.resume.controller;
+
+import com.example.resume.model.ResumeData;
+import com.example.resume.model.ResumeSection;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class ResumeController {
+
+    @GetMapping("/resume")
+    public String showForm(HttpSession session, Model model) {
+        ResumeData data = (ResumeData) session.getAttribute("resume");
+        if (data == null) {
+            data = new ResumeData();
+        }
+        model.addAttribute("resumeData", data);
+        return "resumeForm";
+    }
+
+    @PostMapping("/resume")
+    public String submitForm(@RequestParam String name,
+                             @RequestParam String email,
+                             @RequestParam(required = false) String phone,
+                             @RequestParam(name = "sectionTitles", required = false) List<String> sectionTitles,
+                             @RequestParam(name = "sectionContents", required = false) List<String> sectionContents,
+                             HttpSession session) {
+        ResumeData data = new ResumeData();
+        data.setName(name);
+        data.setEmail(email);
+        data.setPhone(phone);
+
+        List<ResumeSection> sections = new ArrayList<>();
+        if (sectionTitles != null && sectionContents != null) {
+            for (int i = 0; i < Math.min(sectionTitles.size(), sectionContents.size()); i++) {
+                String t = sectionTitles.get(i);
+                String c = sectionContents.get(i);
+                if ((t != null && !t.isBlank()) || (c != null && !c.isBlank())) {
+                    sections.add(new ResumeSection(t, c));
+                }
+            }
+        }
+        data.setSections(sections);
+        session.setAttribute("resume", data);
+        return "redirect:/resume/view";
+    }
+
+    @GetMapping("/resume/view")
+    public String viewResume(HttpSession session, Model model) {
+        ResumeData data = (ResumeData) session.getAttribute("resume");
+        if (data == null) {
+            return "redirect:/resume";
+        }
+        model.addAttribute("resume", data);
+        return "resumeView";
+    }
+}

--- a/src/main/java/com/example/resume/model/ResumeData.java
+++ b/src/main/java/com/example/resume/model/ResumeData.java
@@ -1,0 +1,43 @@
+package com.example.resume.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResumeData {
+    private String name;
+    private String email;
+    private String phone;
+    private List<ResumeSection> sections = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public List<ResumeSection> getSections() {
+        return sections;
+    }
+
+    public void setSections(List<ResumeSection> sections) {
+        this.sections = sections;
+    }
+}

--- a/src/main/java/com/example/resume/model/ResumeSection.java
+++ b/src/main/java/com/example/resume/model/ResumeSection.java
@@ -1,0 +1,29 @@
+package com.example.resume.model;
+
+public class ResumeSection {
+    private String title;
+    private String content;
+
+    public ResumeSection() {}
+
+    public ResumeSection(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/resources/templates/resumeForm.html
+++ b/src/main/resources/templates/resumeForm.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Resume Form</title>
+    <script>
+        function addSection() {
+            const container = document.getElementById('sections');
+            const index = container.children.length;
+            const div = document.createElement('div');
+            div.innerHTML = '<input type="text" name="sectionTitles" placeholder="Section Title" />' +
+                '<br/>' +
+                '<textarea name="sectionContents" placeholder="Content"></textarea><hr/>';
+            container.appendChild(div);
+        }
+    </script>
+</head>
+<body>
+<h1>Create Resume</h1>
+<form th:action="@{/resume}" method="post">
+    <label>Name: <input type="text" name="name" th:value="${resumeData.name}" required/></label><br/>
+    <label>Email: <input type="email" name="email" th:value="${resumeData.email}" required/></label><br/>
+    <label>Phone: <input type="text" name="phone" th:value="${resumeData.phone}"/></label><br/>
+    <h3>Sections</h3>
+    <div id="sections">
+        <div th:each="section, iterStat : ${resumeData.sections}">
+            <input type="text" name="sectionTitles" th:value="${section.title}" placeholder="Section Title" />
+            <br/>
+            <textarea name="sectionContents" placeholder="Content" th:text="${section.content}"></textarea>
+            <hr/>
+        </div>
+    </div>
+    <button type="button" onclick="addSection()">Add Section</button>
+    <br/>
+    <button type="submit">Submit</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/resumeView.html
+++ b/src/main/resources/templates/resumeView.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Resume</title>
+</head>
+<body>
+<h1 th:text="${resume.name}">Name</h1>
+<p>Email: <span th:text="${resume.email}"></span></p>
+<p th:if="${resume.phone}">Phone: <span th:text="${resume.phone}"></span></p>
+<div th:each="section : ${resume.sections}">
+    <h2 th:text="${section.title}">Section Title</h2>
+    <p th:text="${section.content}">Content</p>
+</div>
+<a href="/resume">Edit</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize Spring Boot project with Maven
- add a `ResumeController` to accept resume data
- add models for resume data/sections
- provide simple Thymeleaf templates for creating and viewing resumes

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff802221c8322a448fd315f1efebc