### PR TITLE
Add Flask resume service

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, request, jsonify, render_template, make_response
+import pdfkit
+
+app = Flask(__name__)
+
+# Simple in-memory storage for resumes
+resumes = {}
+
+@app.route('/resumes', methods=['POST'])
+def create_resume():
+    data = request.get_json()
+    if not data or 'id' not in data:
+        return jsonify({'error': 'Resume must include an id'}), 400
+    resume_id = data['id']
+    resumes[resume_id] = data
+    return jsonify({'message': 'Resume stored', 'id': resume_id}), 201
+
+@app.route('/resumes/<resume_id>', methods=['GET'])
+def get_resume(resume_id):
+    resume = resumes.get(resume_id)
+    if not resume:
+        return jsonify({'error': 'Resume not found'}), 404
+    return jsonify(resume)
+
+@app.route('/resumes/<resume_id>/html', methods=['GET'])
+def get_resume_html(resume_id):
+    resume = resumes.get(resume_id)
+    if not resume:
+        return jsonify({'error': 'Resume not found'}), 404
+    html = render_template('resume.html', resume=resume)
+    return html
+
+@app.route('/resumes/<resume_id>/pdf', methods=['GET'])
+def get_resume_pdf(resume_id):
+    resume = resumes.get(resume_id)
+    if not resume:
+        return jsonify({'error': 'Resume not found'}), 404
+    html = render_template('resume.html', resume=resume)
+    # pdfkit requires wkhtmltopdf installed in the environment
+    pdf = pdfkit.from_string(html, False)
+    response = make_response(pdf)
+    response.headers['Content-Type'] = 'application/pdf'
+    response.headers['Content-Disposition'] = f'attachment; filename={resume_id}.pdf'
+    return response
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pdfkit
+Jinja2

--- a/templates/resume.html
+++ b/templates/resume.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Resume</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        h1 { font-size: 24px; margin-bottom: 10px; }
+        h2 { font-size: 20px; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>{{ resume.get('name', 'Unnamed') }}</h1>
+    <h2>Education</h2>
+    <p>{{ resume.get('education', 'N/A') }}</p>
+    <h2>Skills</h2>
+    <ul>
+        {% for skill in resume.get('skills', []) %}
+        <li>{{ skill }}</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a basic Flask app
- add resume template
- provide requirements file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ff804c85c832285c4b42fcfbb59f8